### PR TITLE
messages are mistakenly ignored by jabber-plugin

### DIFF
--- a/src/main/java/hudson/plugins/jabber/im/transport/JabberIMConnection.java
+++ b/src/main/java/hudson/plugins/jabber/im/transport/JabberIMConnection.java
@@ -600,31 +600,13 @@ class JabberIMConnection extends AbstractIMConnection {
 			if (packet instanceof Message) {
 				Message m = (Message)packet;
 
-				boolean composing = false;
-				boolean xhtmlMessage = false;
 				for (PacketExtension ext : m.getExtensions()) {
 					if (ext instanceof DelayInformation) {
 						// ignore delayed messages
 						return;
 					}
-					if (ext instanceof MessageEvent) {
-						MessageEvent me = (MessageEvent)ext;
-						if (me.isComposing()) {
-							// ignore messages which are still being composed
-							composing = true;
-						}
-					}
-					if (ext instanceof XHTMLExtension) {
-						xhtmlMessage = true;
-					}
 				}
-				
-				if (composing && !xhtmlMessage) {
-					// pretty strange: if composing extension AND NOT XHTMLExtension, this seems
-					// to mean that the message was delivered
-					return;
-				}
-				
+                
 				if (m.getBody() != null) {
 					LOGGER.info("Message from " + m.getFrom() + " : " + m.getBody());
 					


### PR DESCRIPTION
Nowdays non-xhtml messages from clients that are ready to receive
events relating to the delivery, display, and composition of messages
are erroneously ignored by jabber plugin.

According to http://xmpp.org/extensions/xep-0022.html (Section 3.1)
if message has body and any (or all) of isOffline(), isDelivered(),
isComposing(), isDisplayed() flags set to `true', that means that
the sender wants to be notified if the message is stored offline
(by the server), notified when the message is delivered (to the
client), notified if the recipient begins replying to the message
and notified when the message is displayed to recipient.

So, In case of presence of body element these flags are absolutely
unrelated to current state of given message. Additional checks
should not be performed.
