### PR TITLE
Remove deprecated Java 7 note & raise source compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,6 @@ This plugin needs the [instant-messaging
 plugin](http://wiki.jenkins-ci.org/display/JENKINS/Instant+Messaging+Plugin).
 Please ensure that the latest version of this plug-in is also installed.
 
-### Java 7 Needed
-
-Note that since version 1.26 Java 7 is needed as a requirement to run
-the plugin.
-
 ### Features
 
 See [instant-messaging

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ repositories {
 	mavenCentral()
 }
 
-sourceCompatibility = 1.7
+sourceCompatibility = 1.8
 targetCompatibility = sourceCompatibility
 
 dependencies {


### PR DESCRIPTION
In commit 14f96c19b4910dc970341654076dffb3df3add52 the minimum required Jenkins version was raised to 2.164. This is a version that requires Java 8. Jenkins 2.60.1 was the first version that required Java 8, see https://jenkins.io/changelog-stable/#v2.60.1