### PR TITLE
[JENKINS-54064] Bundle classes as JAR file into HPI file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "org.jenkins-ci.jpi" version "0.33.0"
+  id 'org.jenkins-ci.jpi' version '0.36.2'
 }
 
 apply plugin: 'eclipse'


### PR DESCRIPTION
In version 0.36.0 of the jpi plugin bundling the classes has been changed.
Instead of putting them into the HPI file under `WEB-INF/classes/`, they are
now put into a JAR file under `WEB-INF/lib/`. This is required for Jenkins
JAR file prefetching & caching to work properly (see JENKINS-15120).