### PR TITLE
Introduce .mvn: generic migration to incrementals (transplant from ircbot-plugin)

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>io.jenkins.tools.incrementals</groupId>
+    <artifactId>git-changelist-maven-extension</artifactId>
+    <version>1.2</version>
+  </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Pconsume-incrementals
+-Pmight-produce-incrementals

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.2//EN" "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+<module name="Checker">
+    <module name="FileTabCharacter" />
+    <module name="NewlineAtEndOfFile" />
+    <module name="RegexpSingleline">
+        <property name="format" value="\s+$"/>
+        <property name="message" value="Trailing spaces are not allowed."/>
+    </module>
+    <module name="TreeWalker">
+        <module name="ImportOrder">
+            <property name="groups" value="*,com,edu,hudson,io,java,javax,jenkins,net,okhttp3,org.apache,org.jenkinsci,org.jvnet.hudson,org.junit,org.kohsuke,org.pircbotx,org" />
+            <property name="ordered" value="true"/>
+            <property name="separated" value="true"/>
+            <property name="option" value="bottom"/>
+            <property name="sortStaticImportsAlphabetically" value="true"/>
+            <!-- See also https://github.com/checkstyle/checkstyle/issues/5476
+                 and https://github.com/checkstyle/checkstyle/issues/7425
+              -->
+        </module>
+        <module name="UnusedImports" />
+    </module>
+</module>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>plugin</artifactId>
+        <version>4.25</version>
+        <relativePath />
+    </parent>
+
+    <groupId>org.jvnet.hudson.plugins</groupId>
+    <artifactId>jabber</artifactId>
+    <packaging>hpi</packaging>
+    <version>${revision}${changelist}</version>
+
+    <name>Jenkins Jabber Plugin</name>
+    <description>
+A build status publisher that notifies channels on a Jabber server
+(Note: the "bot" part is mostly in instant-messaging-plugin)
+</description>
+    <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
+    <inceptionYear>2006</inceptionYear>
+
+    <licenses>
+        <license>
+            <name>MIT license</name>
+            <url>https://opensource.org/licenses/MIT</url>
+            <comments>All source code is under the MIT license.</comments>
+        </license>
+    </licenses>
+
+    <properties>
+        <revision>2.40</revision>
+        <changelist>-SNAPSHOT</changelist>
+        <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
+        <version.instant-messaging.plugin>1.44</version.instant-messaging.plugin>
+        <java.level>8</java.level>
+        <jenkins.version>2.270</jenkins.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.263.x</artifactId>
+                <version>937.v51fde92016ed</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jvnet.hudson.plugins</groupId>
+            <artifactId>instant-messaging</artifactId>
+            <version>${version.instant-messaging.plugin}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jenkins-ci.main</groupId>
+            <artifactId>maven-plugin</artifactId>
+            <version>3.12</version>
+            <exclusions>
+                <!-- TODO conflict with jenkins-test-harness that wants a newer
+                     version currently, see comments in
+                     https://github.com/jenkinsci/instant-messaging-plugin/pull/50
+                -->
+                <exclusion>
+                    <groupId>commons-net</groupId>
+                    <artifactId>commons-net</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- Jenkins pipeline support below -->
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-step-api</artifactId>
+        </dependency>
+
+    </dependencies>
+
+    <repositories>
+        <repository>
+            <id>repo.jenkins-ci.org</id>
+            <url>https://repo.jenkins-ci.org/public/</url>
+        </repository>
+        <repository>
+            <id>jenkins-snapshots</id>
+            <url>https://repo.jenkins-ci.org/content/repositories/snapshots</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
+    <developers>
+        <developer>
+            <id>Flowdalic</id>
+            <name>Florian Schmaus</name>
+            <email>flo@geekplace.eu</email>
+            <timezone>1</timezone>
+        </developer>
+    </developers>
+
+    <scm>
+        <connection>scm:git:git://github.com/${gitHubRepo}.git</connection>
+        <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+        <url>https://github.com/${gitHubRepo}</url>
+        <tag>${scmTag}</tag>
+    </scm>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>repo.jenkins-ci.org</id>
+            <url>https://repo.jenkins-ci.org/public/</url>
+        </pluginRepository>
+    </pluginRepositories>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>3.1.2</version>
+                <configuration>
+                    <configLocation>${basedir}/checkstyle.xml</configLocation>
+                    <includeTestSourceDirectory>true</includeTestSourceDirectory>
+                    <sourceDirectories>
+                        <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
+                    </sourceDirectories>
+                    <testSourceDirectories>
+                        <sourceDirectory>${project.build.testSourceDirectory}</sourceDirectory>
+                    </testSourceDirectories>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jenkins-ci.tools</groupId>
+                <artifactId>maven-hpi-plugin</artifactId>
+                <configuration>
+                    <loggers>
+                        <hudson.plugins.im>FINE</hudson.plugins.im>
+                    </loggers>
+                    <compatibleSinceVersion>2.0</compatibleSinceVersion>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,14 @@ A build status publisher that notifies channels on a Jabber server
             <artifactId>instant-messaging</artifactId>
             <version>${version.instant-messaging.plugin}</version>
         </dependency>
+        <dependency>
+            <groupId>org.jivesoftware</groupId>
+            <artifactId>smack</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jivesoftware</groupId>
+            <artifactId>smackx</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.jenkins-ci.main</groupId>


### PR DESCRIPTION
Hi @Flowdalic : as a sibling to PR #26, this one tries to introduce the bits needed for Maven builds of the project, its dependency tracking and so on. Generic rituals were applied, but e.g. the dependency names/locations/versions need to be spelled out so I hope you can edit this PR branch and rectify that :)

Eventually, after `mvn package` works well, you can modify the Jenkinsfile to use this mechanism: https://github.com/jenkinsci/ircbot-plugin/blob/master/Jenkinsfile

Normally you would call just `buildPlugin()` but recently the (docker) systems it is using by default were unstable, so calling explicitly container ones as spelled in that current file may be better. If defaults change by the time you get to this, so be it :)